### PR TITLE
track session gtids

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ const pool = createMonotonePool({
 
 ### MySQL Configuration Requirements
 
-Monotone requires specific MySQL configuration to function properly. The following settings must be enabled on both your primary and replica MySQL servers:
+Monotone requires **MySQL 5.7 or later** to function properly. This is because the library relies on GTID (Global Transaction Identifier) functionality and the `WAIT_FOR_EXECUTED_GTID_SET` function, which were introduced in MySQL 5.7.
+
+The following settings must be enabled on both your primary and replica MySQL servers:
 
 #### Primary Database Configuration
 

--- a/src/monotone.ts
+++ b/src/monotone.ts
@@ -249,6 +249,11 @@ function createPoolProxy({
  */
 export const createMonotonePool = (options: MonotoneOptions): Pool => {
   const primary = createPool(options.primary);
+
+  // track session ids so they are returned on writes
+  primary.on('connection', async (conn) => {
+    await conn.query('SET SESSION session_track_gtids = OWN_GTID');
+  });
   const replicas = options.replicas.map((replicaConfig) =>
     createPool(replicaConfig),
   );


### PR DESCRIPTION
### TL;DR

Added MySQL 5.7 requirement to documentation and configured session tracking for GTIDs.

### What changed?

- Updated README to specify that Monotone requires MySQL 5.7 or later due to its dependency on GTID functionality and the `WAIT_FOR_EXECUTED_GTID_SET` function
- Added connection event handler to the primary database pool that sets `session_track_gtids = OWN_GTID` for each new connection, ensuring GTIDs are returned on write operations

### How to test?

1. Verify that connections to the primary database have the `session_track_gtids` setting enabled
2. Confirm that write operations return the appropriate GTID information
3. Test with both MySQL 5.7+ and earlier versions to confirm version requirements

### Why make this change?

This change ensures proper GTID tracking for the replication functionality in Monotone. By explicitly setting `session_track_gtids = OWN_GTID`, we ensure that write operations return the necessary GTID information needed for the library's read-after-write consistency features. The documentation update clarifies the MySQL version requirement to prevent compatibility issues.